### PR TITLE
Generate full Git log CSV telemetry for each RST file

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,17 @@ Changes
 Unreleased
 ==========
 
+- The `qa` target now generates full git log CSV files for each RST file,
+  including commit subject. Subject lines can be scanned for keywords (by future
+  QA tooling) to help classify commits.
+
+  In the future, additional QA tools can be developed to generate additional
+  CSV files. For example, to record information reported by Vale.
+
+  The filename stem used by each CSV file can be used to determine the relevant
+  source RST file.
+
+
 0.4.0 - 2020/09/29
 ==================
 

--- a/src/bin/git-log
+++ b/src/bin/git-log
@@ -23,8 +23,7 @@
 SOURCE_FILE=${1}
 CSV_FILE=${2}
 
-echo "Scanning: ${SOURCE_FILE}"
-echo "modified, reviewed" > ${CSV_FILE}
-modified=$(git log -1 --date=iso --format="%ad" ${SOURCE_FILE})
-reviewed=$(head ${SOURCE_FILE} | grep -i ":reviewed:" | sed "s,.*: ,,")
-echo "${modified}, ${reviewed}" >> ${CSV_FILE}
+echo "Writing: ${CSV_FILE}"
+git log --no-merges --date=iso \
+    --pretty=format:'"%ad","%H","%an","%ae","%s"' -- index.rst | \
+    paste - > ${CSV_FILE}

--- a/src/rules.mk
+++ b/src/rules.mk
@@ -45,7 +45,7 @@ VALE            := $(TOOLS_DIR)/vale
 VALE_OPTS       := --config=$(SRC_DIR)/_vale.ini
 LINT            := $(SRC_DIR)/bin/lint
 LINT_DIR        := $(LOCAL_DIR)/lint/$(DOCS_DIR)
-QA              := $(SRC_DIR)/bin/qa
+GIT_LOG         := $(SRC_DIR)/bin/git-log
 QA_DIR          := $(LOCAL_DIR)/qa/$(DOCS_DIR)
 FSWATCH         := fswatch
 
@@ -75,7 +75,7 @@ source_files := $(sort $(shell \
 
 # Generate targets
 lint_targets := $(patsubst %.rst,%.csv,$(patsubst %,$(LINT_DIR)/%,$(source_files)))
-qa_targets := $(patsubst %.rst,%.csv,$(patsubst %,$(QA_DIR)/%,$(source_files)))
+git_log_targets := $(patsubst %.rst,%.git-log.csv,$(patsubst %,$(QA_DIR)/%,$(source_files)))
 
 .PHONY: help
 help:
@@ -223,13 +223,13 @@ $(QA_DIR):
 qa-deps: $(QA_DIR)
 
 # Generate QA telemetry for a file
-$(QA_DIR)/%.csv: %.rst
+$(QA_DIR)/%.git-log.csv: %.rst
 	@ if test -n '$(dir $@)'; then \
 	    mkdir -p '$(dir $@)'; \
 	fi
-	@ $(QA) '$<' '$@'
+	@ $(GIT_LOG) '$<' '$@'
 
 .PHONY: qa
-qa: qa-deps $(qa_targets)
+qa: qa-deps $(git_log_targets)
 	@ # Do not error out when linting for QA telemetry
 	@ VALE_NO_EXIT=1 $(MAKE) check


### PR DESCRIPTION
for https://github.com/crate/tech-writing-domain/issues/360

---

The `qa` target now generates full git log CSV files for each RST file,
including commit subject. Subject lines can be scanned for keywords (by future
QA tooling) to help classify commits.

In the future, additional QA tools can be developed to generate additional
CSV files. For example, to record information reported by Vale.

The filename stem used by each CSV file can be used to determine the relevant
source RST file.