### PR TITLE
Pass target (`html` or `linkcheck`) through to `sphinx-build`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,9 @@ Changes
 Unreleased
 ==========
 
+- Pass target (`html` or `linkcheck`) through to `sphinx-build` (fixes
+  https://github.com/crate/crate-docs/issues/30)
+
 - The `qa` target now generates full git log CSV files for each RST file,
   including commit subject. Subject lines can be scanned for keywords (by future
   QA tooling) to help classify commits.

--- a/src/rules.mk
+++ b/src/rules.mk
@@ -162,7 +162,7 @@ lint: lint-deps $(lint_targets)
 .PHONY: html linkcheck
 html linkcheck: $(ACTIVATE) $(SPHINXBUILD)
 	. $(ACTIVATE) && \
-	    $(SPHINXBUILD) $(SPHINX_ARGS) $(SPHINX_OPTS) $(O)
+	    $(SPHINXBUILD) $(SPHINX_ARGS) $(SPHINX_OPTS) -b $(@) $(O)
 
 .PHONY: autobuild-deps
 autobuild-deps: $(SPHINXAUTOBUILD)


### PR DESCRIPTION
fixes https://github.com/crate/crate-docs/issues/30
