### PR TITLE
Relax Python version to "python3"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 .crate-docs
+.idea

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,9 @@ Changes
 Unreleased
 ==========
 
+- Relax Makefile constraint to specifically use Python 3.7.
+  Now, any version of Python >= 3.7 is allowed.
+
 - Disable `proselint.Annotations` so that using `**NOTE**` in standalone RST
   files does not raise an error.
 

--- a/src/rules.mk
+++ b/src/rules.mk
@@ -24,7 +24,7 @@ LOCAL_DIR       := $(patsubst %/src/,%,$(dir $(lastword $(MAKEFILE_LIST))))
 SRC_DIR         := $(LOCAL_DIR)/src
 ENV_DIR         := $(LOCAL_DIR)/env
 ACTIVATE        := $(ENV_DIR)/bin/activate
-PYTHON          := python3.7
+PYTHON          := python3
 PIP             := $(PYTHON) -m pip
 SPHINXBUILD     := $(ENV_DIR)/bin/sphinx-build
 SPHINXAUTOBUILD := $(ENV_DIR)/bin/sphinx-autobuild
@@ -98,6 +98,12 @@ help:
 	@ printf '\033[37m  reset  \033[00m Reset the build\n'
 
 $(ACTIVATE):
+
+	@# Check Python version.
+	@# Currently, this asserts Python>=3.7.
+	@$(PYTHON) -c 'import sys; assert sys.version_info >= (3, 7), "Requires Python>=3.7"'
+
+	@# Create Python virtualenv.
 	$(PYTHON) -m venv $(ENV_DIR)
 	. $(ACTIVATE) && \
 	    $(PIP) install --upgrade pip


### PR DESCRIPTION
Hi there,

Python 3.7 was not installed on my machine and I believe it might be fine to just say `python3` in the dependencies instead of `python3.7`. If something fails on that, people using this will probably have to go to `pyenv` anyway.

With kind regards,
Andreas.
