### PR TITLE
Use a dot prefix for the Python virtualenv

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,10 @@ Changes
 Unreleased
 ==========
 
+- Use ``.venv`` as a directory under ``.crate-docs`` for
+  hosting the built-in virtualenv. This prevents many
+  search tools crossing that boundary.
+
 - Relax Makefile constraint to specifically use Python 3.7.
   Now, any version of Python >= 3.7 is allowed.
 

--- a/src/rules.mk
+++ b/src/rules.mk
@@ -22,7 +22,7 @@
 
 LOCAL_DIR       := $(patsubst %/src/,%,$(dir $(lastword $(MAKEFILE_LIST))))
 SRC_DIR         := $(LOCAL_DIR)/src
-ENV_DIR         := $(LOCAL_DIR)/env
+ENV_DIR         := $(LOCAL_DIR)/.venv
 ACTIVATE        := $(ENV_DIR)/bin/activate
 PYTHON          := python3
 PIP             := $(PYTHON) -m pip


### PR DESCRIPTION
This tremendously helps when searching the whole tree for tokens from within downstream repositories with tools like `ag` or `ripgrep`, like:
```
$ cd /path/to/crate-howtos/docs
$ ag check .crate-docs
```
By hiding away the Python virtualenv, searching the tree usually does not cross this boundary.
