### PR TITLE
Bump Sphinx requirement to use its most recent version

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,9 @@ Changes
 Unreleased
 ==========
 
+- We are transitioning to Sphinx 3.x., so the specific requirement
+  to use Sphinx 1.7.4 has been relaxed to allow all of Sphinx <4.
+
 - Use ``.venv`` as a directory under ``.crate-docs`` for
   hosting the built-in virtualenv. This prevents many
   search tools crossing that boundary.

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,11 +1,10 @@
 # Standard packages needed for the docs
 ###############################################################################
 
-docutils==0.14
+docutils>=0.14
 sphinx-autobuild
 
 # These versions should match the Read The Docs environment (please update if
 # you notice this is not the case)
-alabaster>=0.7,<0.8,!=0.7.5
 setuptools<41
-sphinx==1.7.4
+sphinx>=1.8.5,<4


### PR DESCRIPTION
Hi there,

this bumps to Sphinx>=1.8.5. I am aware we might have to sync upstream repositories with this update, but c'est la vie. I believe the most important thing has been to relax the constraints on `crate-docs-theme`, which has already been done through https://github.com/crate/crate-docs-theme/pull/233.

With kind regards,
Andreas.

Improves #38.