### PR TITLE
Use recent version of setuptools to add compatibility with Python3.9

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,19 +7,20 @@ on:
 
 jobs:
   documentation:
-    name: Build docs on ${{ matrix.os }}
+    name: Build docs on ${{ matrix.os }} using Python ${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
 
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
+        python-version: ["3.7", "3.8", "3.9"]
 
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python
         uses: actions/setup-python@v1
         with:
-          python-version: 3.7
+          python-version: ${{ matrix.python-version }}
       - name: Build docs
         run: |
           cd docs && make check

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -6,5 +6,5 @@ sphinx-autobuild
 
 # These versions should match the Read The Docs environment (please update if
 # you notice this is not the case)
-setuptools<41
+setuptools>=41.1.0
 sphinx>=1.8.5,<4


### PR DESCRIPTION
By relaxing the constraint of the `setuptools` package, we allow more recent versions. In turn, this adds compatibility with Python 3.9.

Fixes #47.

