### PR TITLE
Run RTD build using pinned Sphinx version

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,10 @@ Unreleased
       project that can be used to test the other tools within this very
       repository.
 
+- Use explicit version pinning for the Sphinx release, adhering to RTD's
+  recommendations about reproducible builds. Currently, we are using
+  Sphinx 3.5.3.
+
 
 1.0.0 - 2021/03/22
 ==================

--- a/common-build/requirements.txt
+++ b/common-build/requirements.txt
@@ -7,4 +7,4 @@ sphinx-autobuild
 # These versions should match the Read The Docs environment (please update if
 # you notice this is not the case)
 setuptools>=41.1.0
-sphinx>=1.8.5,<4
+sphinx==3.5.3

--- a/demo-docs/requirements.txt
+++ b/demo-docs/requirements.txt
@@ -1,1 +1,2 @@
+sphinx==3.5.2
 crate-docs-theme

--- a/demo-docs/requirements.txt
+++ b/demo-docs/requirements.txt
@@ -1,2 +1,2 @@
-sphinx==3.5.2
+sphinx==3.5.3
 crate-docs-theme


### PR DESCRIPTION
Out of curiosity, this checks the RTD build using a pinned Sphinx version. This is all about investigating the default/non-default behavior related to https://github.com/readthedocs/readthedocs.org/issues/6296.

The background on that is that the RTD build says it is _Running Sphinx v1.8.5_ [1] when running on a loose constraint like `Sphinx>=1.8.5,<4` as defined within [`crate-docs-theme`](https://github.com/crate/crate-docs-theme) [2], which is pulled in as a dependency.

[1] https://readthedocs.org/projects/crate-docs/builds/12559570/
[2] https://github.com/crate/crate-docs-theme/blob/0.12.0/setup.py#L56