### PR TITLE
Improve our style guide wrt RST headings

### DIFF
--- a/style/rst.rst
+++ b/style/rst.rst
@@ -139,13 +139,31 @@ Follow these markup conventions for title and headings:
     --------------------
 
     Third-level heading
-    ~~~~~~~~~~~~~~~~~~~
+    """""""""""""""""""
 
     Fourth-level heading
-    ^^^^^^^^^^^^^^^^^^^^
+    ''''''''''''''''''''
 
     Fifth-level heading
-    ...................
+    ````````````````````
+
+These underlines were chosen to satisfy the following requirements:
+
+1. Honor the well-established practice of using `=` and `-` for the first three
+   heading levels.
+
+2. Underlines should resemble properly typeset underlines (i.e., a single
+   continuous line) as much as possible.
+
+   This rules out symbols that do not create the impression of a standard
+   underline. Additionally, underlines should sit somewhere between `the median
+   and the cap hight`_. Symbols that sit on the baseline leave an undesirable
+   amount of vertical space between the underline and the heading text
+
+4. The visual prominence (defined here as the combination of `point size`_ and
+   `type color`_) of the underline should decrease with heading depth (e.g.,
+   the fourth-level heading should be less prominent than the third-level
+   heading).
 
 As a general principle, we use the imperative mood for top-level document
 titles where an action is relevant. E.g., correct:
@@ -460,5 +478,8 @@ Incorrect sort order:
     .. _Elasticsearch: http://www.elasticsearch.org/
 
 
+.. _point size: https://en.wikipedia.org/wiki/Point_(typography)
 .. _sentence case: https://en.wiktionary.org/wiki/sentence_case
+.. _the median and the cap hight: https://en.wikipedia.org/wiki/Baseline_(typography)#/media/File:Typography_Line_Terms.svg
 .. _title case: http://individed.com/code/to-title-case/
+.. _type color:https://en.wikipedia.org/wiki/Type_color


### PR DESCRIPTION
previously, our style guide for the lower-level RST headings was poorly thought out. I spent some time today trying to rethink this from a typography perspective and this is what I came up with

I looked at the RST spec, found the list of valid characters, and cut the list down to characters that actually resemble properly typeset underlines, and then ranked them by visual prominence so as to mirror the way that headings are typeset in a "rich text" document

the convention of using "=" and "-" was a bit of a limiting factor and I had to work around that. the convention is so strong at Crate and so widely spread, that I consider it unfeasible (and a poor use of time) to attempt to change it. the lower level headings are rarely used and where they are used, they usually do not follow our previous style guide because they were put in place before our style guide was adopted. so, my reasoning is: updating our style guide now, before too many additional changes have been made, is a net benefit

(for context: I only sporadically update heading markup. typically if I am in the doc making other changes for a story or what have you. so I've only done it once or twice. certainly not enough to justify "freezing" the style guide)