### PR TITLE
When running Vale, also ignore the repository-local "eggs" folder

### DIFF
--- a/common-build/rules.mk
+++ b/common-build/rules.mk
@@ -70,7 +70,7 @@ NO_VALE_FILE    = $(TOP_DIR)/$(DOCS_DIR)/_no_vale
 TOOLS_DIR       = $(LOCAL_DIR)/tools
 STYLE_DIR       = $(LOCAL_DIR)/tools/styles
                   # Ignore RST files matching these globs (space separated)
-GLOBS           = */.* */style/* */site-packages/* */vendor/*
+GLOBS           = */.* */style/* */site-packages/* */eggs/* */vendor/*
                   # Package globs for the `find` program
 FIND_OPTS       = $(foreach glob,$(GLOBS),-path '$(glob)' -prune -o)
 FIND_RST        = cd $(TOP_DIR) && find . $(FIND_OPTS) -name '*.rst' -print


### PR DESCRIPTION
Hi,

while working on https://github.com/crate/crate-python/pull/408, I found that Vale would also check contents within a local `eggs` folder. This patch mitigates that situation.

With kind regards,
Andreas.