### PR TITLE
Update license boilerplate

### DIFF
--- a/common-build/bin/git-log
+++ b/common-build/bin/git-log
@@ -1,23 +1,23 @@
 #!/bin/sh -e
 
-# Licensed to Crate (https://crate.io) under one or more contributor license
-# agreements.  See the NOTICE file distributed with this work for additional
-# information regarding copyright ownership.  Crate licenses this file to you
-# under the Apache License, Version 2.0 (the "License"); you may not use this
-# file except in compliance with the License.  You may obtain a copy of the
-# License at
+# Licensed to Crate.io GmbH ("Crate") under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  Crate licenses
+# this file to you under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.  You may
+# obtain a copy of the License at
 #
 #   http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
-# License for the specific language governing permissions and limitations under
-# the License.
+# License for the specific language governing permissions and limitations
+# under the License.
 #
-# However, if you have executed another commercial license agreement with Crate
-# these terms will supersede the license and you may use the software solely
-# pursuant to the terms of the relevant commercial agreement.
+# However, if you have executed another commercial license agreement
+# with Crate these terms will supersede the license and you may use the
+# software solely pursuant to the terms of the relevant commercial agreement.
 
 
 SOURCE_FILE=${1}

--- a/common-build/rules.mk
+++ b/common-build/rules.mk
@@ -1,21 +1,22 @@
-# Licensed to Crate (https://crate.io) under one or more contributor license
-# agreements.  See the NOTICE file distributed with this work for additional
-# information regarding copyright ownership.  Crate licenses this file to you
-# under the Apache License, Version 2.0 (the "License"); you may not use this
-# file except in compliance with the License.  You may obtain a copy of the
-# License at
+# Licensed to Crate.io GmbH ("Crate") under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  Crate licenses
+# this file to you under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.  You may
+# obtain a copy of the License at
 #
 #   http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
-# License for the specific language governing permissions and limitations under
-# the License.
+# License for the specific language governing permissions and limitations
+# under the License.
 #
-# However, if you have executed another commercial license agreement with Crate
-# these terms will supersede the license and you may use the software solely
-# pursuant to the terms of the relevant commercial agreement.
+# However, if you have executed another commercial license agreement
+# with Crate these terms will supersede the license and you may use the
+# software solely pursuant to the terms of the relevant commercial agreement.
+
 
 # =============================================================================
 # Core build system

--- a/devs/tools/create_tag.sh
+++ b/devs/tools/create_tag.sh
@@ -1,6 +1,6 @@
 #!/bin/sh -e
 
-# Licensed to Crate (https://crate.io) under one or more contributor
+# Licensed to Crate.io GmbH ("Crate") under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  Crate licenses
 # this file to you under the Apache License, Version 2.0 (the "License");
@@ -18,6 +18,7 @@
 # However, if you have executed another commercial license agreement
 # with Crate these terms will supersede the license and you may use the
 # software solely pursuant to the terms of the relevant commercial agreement.
+
 
 # Check if everything is committed
 CLEAN=`git status -s`

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,21 +1,21 @@
-# Licensed to Crate (https://crate.io) under one or more contributor license
-# agreements.  See the NOTICE file distributed with this work for additional
-# information regarding copyright ownership.  Crate licenses this file to you
-# under the Apache License, Version 2.0 (the "License"); you may not use this
-# file except in compliance with the License.  You may obtain a copy of the
-# License at
+# Licensed to Crate.io GmbH ("Crate") under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  Crate licenses
+# this file to you under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.  You may
+# obtain a copy of the License at
 #
 #   http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
-# License for the specific language governing permissions and limitations under
-# the License.
+# License for the specific language governing permissions and limitations
+# under the License.
 #
-# However, if you have executed another commercial license agreement with Crate
-# these terms will supersede the license and you may use the software solely
-# pursuant to the terms of the relevant commercial agreement.
+# However, if you have executed another commercial license agreement
+# with Crate these terms will supersede the license and you may use the
+# software solely pursuant to the terms of the relevant commercial agreement.
 
 
 # =============================================================================

--- a/helpers/check-crate-conf
+++ b/helpers/check-crate-conf
@@ -1,5 +1,25 @@
 #!/bin/sh -e
 
+# Licensed to Crate.io GmbH ("Crate") under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  Crate licenses
+# this file to you under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.  You may
+# obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# However, if you have executed another commercial license agreement
+# with Crate these terms will supersede the license and you may use the
+# software solely pursuant to the terms of the relevant commercial agreement.
+
+
 # Check the `crate.yml` configuration file
 #
 # Instructions:

--- a/helpers/outline-headings
+++ b/helpers/outline-headings
@@ -1,5 +1,25 @@
 #!/usr/bin/python3
 
+# Licensed to Crate.io GmbH ("Crate") under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  Crate licenses
+# this file to you under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.  You may
+# obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# However, if you have executed another commercial license agreement
+# with Crate these terms will supersede the license and you may use the
+# software solely pursuant to the terms of the relevant commercial agreement.
+
+
 r"""
 Outline a document's heading structure.
 

--- a/helpers/preview/bin/rst-preview
+++ b/helpers/preview/bin/rst-preview
@@ -1,23 +1,23 @@
 #!/bin/sh -e
 
-# Licensed to Crate (https://crate.io) under one or more contributor license
-# agreements.  See the NOTICE file distributed with this work for additional
-# information regarding copyright ownership.  Crate licenses this file to you
-# under the Apache License, Version 2.0 (the "License"); you may not use this
-# file except in compliance with the License.  You may obtain a copy of the
-# License at
+# Licensed to Crate.io GmbH ("Crate") under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  Crate licenses
+# this file to you under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.  You may
+# obtain a copy of the License at
 #
 #   http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
-# License for the specific language governing permissions and limitations under
-# the License.
+# License for the specific language governing permissions and limitations
+# under the License.
 #
-# However, if you have executed another commercial license agreement with Crate
-# these terms will supersede the license and you may use the software solely
-# pursuant to the terms of the relevant commercial agreement.
+# However, if you have executed another commercial license agreement
+# with Crate these terms will supersede the license and you may use the
+# software solely pursuant to the terms of the relevant commercial agreement.
 
 
 # =============================================================================

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,3 +1,23 @@
+# Licensed to Crate.io GmbH ("Crate") under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  Crate licenses
+# this file to you under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.  You may
+# obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# However, if you have executed another commercial license agreement
+# with Crate these terms will supersede the license and you may use the
+# software solely pursuant to the terms of the relevant commercial agreement.
+
+
 VALE := ../docs/.crate-docs/tools/vale
 
 test:


### PR DESCRIPTION
This change updates the license boilerplate to match that used by the main CrateDB repository.

Closes https://github.com/crate/crate-docs/issues/76
