### PR TITLE
Update Makefile to use python3

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -86,7 +86,7 @@ SRC_MAKE      := $(MAKE) -f $(SRC_DIR)/rules.mk
 
 # Parse the JSON file
 BUILD_VERSION := $(shell cat $(BUILD_JSON) | \
-    python -c 'import json, sys; print(json.load(sys.stdin)["message"])')
+    python3 -c 'import json, sys; print(json.load(sys.stdin)["message"])')
 
 ifeq ($(BUILD_VERSION),)
 $(error No build version specified in `$(BUILD_JSON)`.)


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

Update Makefile to use python3 in JSON parsing

## Checklist

 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
