### PR TITLE
Allow usage on Sphinx 5

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,13 +12,13 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: ["ubuntu-latest", "macos-latest"]
         python-version: ["3.7", "3.8", "3.9"]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - name: Build docs

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,8 @@ Changes
 Unreleased
 ==========
 
+- Allow usage on Sphinx 5
+
 
 2.0.2 - 2022/06/09
 ==================

--- a/common-build/requirements.txt
+++ b/common-build/requirements.txt
@@ -7,4 +7,4 @@ sphinx-autobuild
 # These versions should match the Read The Docs environment (please update if
 # you notice this is not the case)
 setuptools>=41.1.0
-sphinx==3.5.3
+sphinx>=3,<6

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,2 @@
-sphinx==3.5.3
+sphinx>=3,<6
 crate-docs-theme

--- a/helpers/preview/etc/requirements.txt
+++ b/helpers/preview/etc/requirements.txt
@@ -1,3 +1,3 @@
-sphinx==3.5.3
+sphinx>=3,<6
 sphinx-autobuild
 sphinx-rtd-theme


### PR DESCRIPTION
This is needed by https://github.com/crate/crate-docs-theme/pull/349. Otherwise, `crate-docs-theme` would not be able to use Sphinx 5 for running their CI jobs.