### PR TITLE
Fix errors with most recent sphinx-autobuild 2024.2.4

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,8 @@ Unreleased
 
 - CI: Modernize RTD configuration file
 - Fix reference to renamed "CrateDB Documentation Theme" project
+- Fix errors with most recent sphinx-autobuild 2024.2.4 by downgrading
+  to 2021.3.14. It has errors when live reloading.
 
 
 2.1.1 - 2023/07/27

--- a/common-build/requirements.txt
+++ b/common-build/requirements.txt
@@ -2,7 +2,9 @@
 ###############################################################################
 
 docutils>=0.14
-sphinx-autobuild
+
+# Most recent 2024.2.4 has errors on live reloading.
+sphinx-autobuild==2021.3.14
 
 # These versions should match the Read The Docs environment (please update if
 # you notice this is not the case)


### PR DESCRIPTION
... by downgrading to 2021.3.14. It has errors when live reloading.
