### PR TITLE
CI: Just build with one Python version

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,20 +15,19 @@ concurrency:
 
 jobs:
   documentation:
-    name: Build docs on ${{ matrix.os }} using Python ${{ matrix.python-version }}
+    name: Build docs on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
 
     strategy:
       matrix:
         os: ["ubuntu-latest", "macos-latest"]
-        python-version: ["3.10", "3.11"]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: '3.12'
       - name: Build docs
         run: |
           cd docs && make check


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement
Spare some CI cycles.

Is there any reason to build with multiple Python versions?

