### PR TITLE
Start using the `uv` package manager if it's installed

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,6 +1,6 @@
 name: docs
 on:
-  pull_request: ~
+  pull_request:
   push:
     branches:
       - main
@@ -14,8 +14,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
-  documentation:
-    name: Build docs on ${{ matrix.os }}
+
+  with-pip:
+    name: pip on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
 
     strategy:
@@ -28,6 +29,29 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.14'
+      - name: Build docs
+        run: |
+          cd docs && make check
+      - name: Check Vale
+        run: |
+          cd test && make test
+
+  with-uv:
+    name: uv on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os: ["ubuntu-latest", "macos-latest"]
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.14'
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v7
       - name: Build docs
         run: |
           cd docs && make check

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.13'
+          python-version: '3.14'
       - name: Build docs
         run: |
           cd docs && make check

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ Changes
 
 Unreleased
 ==========
+- Started using the ``uv`` package manager if it's installed
 
 2.1.7 - 2025/12/23
 ==================

--- a/common-build/rules.mk
+++ b/common-build/rules.mk
@@ -48,6 +48,8 @@ ENV_DIR         = $(LOCAL_DIR)/.venv
 ACTIVATE        = $(ENV_DIR)/bin/activate
 PYTHON          = python3
 PIP             = $(PYTHON) -m pip
+UV              = uv
+SEED_VIRTUALENV = $(PYTHON) -m venv
 SPHINXBUILD     = $(ENV_DIR)/bin/sphinx-build
 SPHINXAUTOBUILD = $(ENV_DIR)/bin/sphinx-autobuild
 AUTOBUILD_OPTS  = --watch $(TOP_DIR) --re-ignore '^(?!.+\.(?:rst|md|mmd|html|css|js|py|conf)$$)' --open-browser --delay 0
@@ -87,6 +89,12 @@ JQ_FILE_CSV     = $(BIN_DIR)/vale-json-csv.jq
 VALE_OUT_DIR    = $(TELEMETRY_DIR)/vale
 GIT_LOG         = $(BIN_DIR)/git-log
 GIT_LOG_OUT_DIR = $(TELEMETRY_DIR)/git-log
+
+# Figure out if `uv` can be used
+ifneq (, $(shell which $(UV)))
+    PIP := $(UV) pip
+    SEED_VIRTUALENV := uv venv --seed
+endif
 
 # Figure out the OS
 ifeq ($(findstring ;,$(PATH)),;)
@@ -138,7 +146,7 @@ $(ACTIVATE):
 	      printf '\033[31mERROR: Python>=3.7 is required.\033[00m\n'; \
 	      exit 1; \
 	  fi
-	@ $(PYTHON) -m venv $(ENV_DIR)
+	@ $(SEED_VIRTUALENV) $(ENV_DIR)
 	@ . $(ACTIVATE) && \
 	      $(PIP) install --upgrade pip
 
@@ -146,10 +154,10 @@ $(ACTIVATE):
 $(RST2HTML) $(SPHINXBUILD) $(SPHINXAUTOBUILD): $(ACTIVATE)
 	@ printf '\033[1mInstalling Python dependencies...\033[00m\n'
 	@ . $(ACTIVATE) && \
-	      $(PIP) install -r $(SRC_DIR)/requirements.txt
+	      $(PIP) install --upgrade --requirement $(SRC_DIR)/requirements.txt
 	@ # Change to `TOP_DIR` to mimic how Read the Docs does it
 	@ . $(ACTIVATE) && cd $(TOP_DIR) && \
-	      $(PIP) install -r $(DOCS_DIR)/requirements.txt
+	      $(PIP) install --upgrade --requirement $(DOCS_DIR)/requirements.txt
 
 # Configured and run in a sub-make by the $(VALE) target
 install-vale:


### PR DESCRIPTION
## About
Using `uv` speeds up complete sandbox installations from scratch.

## References
- https://github.com/crate/cratedb-guide/pull/513